### PR TITLE
Remove secrets check from PDC as that is now covered in CI pipeline

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
       tins (~> 1.6)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    crass (1.0.4)
     daemons (1.2.4)
     database_cleaner (1.5.3)
     debug_inspector (0.0.2)
@@ -135,7 +136,8 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.8.6)
     kgio (2.11.0)
-    loofah (2.0.3)
+    loofah (2.2.3)
+      crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.6.5)
       mime-types (>= 1.16, < 4)
@@ -175,7 +177,7 @@ GEM
     mutant-rspec (0.8.11)
       mutant (~> 0.8.11)
       rspec-core (>= 3.4.0, < 3.6.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     oauth (0.4.7)
     parallel (1.12.1)
@@ -184,7 +186,7 @@ GEM
     powerpack (0.1.1)
     procto (0.0.3)
     public_suffix (2.0.5)
-    rack (1.6.5)
+    rack (1.6.11)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.7.1)
@@ -204,8 +206,8 @@ GEM
       activesupport (>= 4.2.0.beta, < 5.0)
       nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
-    rails-html-sanitizer (1.0.3)
-      loofah (~> 2.0)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
     railties (4.2.7.1)
       actionpack (= 4.2.7.1)
       activesupport (= 4.2.7.1)
@@ -266,7 +268,7 @@ GEM
     simplecov-html (0.10.0)
     spring (2.0.1)
       activesupport (>= 4.2)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.0)
@@ -352,4 +354,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.4
+   1.16.5

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The pre-deploy checker (PDC) is a tool that correlates commits made to GitHub wi
 * JIRA issues that are in the Ready to Deploy state, but have no commits
 * For JIRA issues that do have commits it identifies issues that:
     * Have the no deploy date or the wrong deploy date
-    * Do not have post deploy checks, secrets checks, migration checks
+    * Do not have post deploy checks, migration checks
     * Are not in the Ready to Deploy state
 The PDC sets the status of the branch to Failed if any of the above checks fail. Users can approve the errant JIRA issues or commits via the UI which will then change the status of the branch to Passed.
 
@@ -67,11 +67,11 @@ ancestor_branches:
 * Install git (>= 2.6.2)
 * Install docker (optional)
 * Configure git authentication to access the repo(s) you want the pre-deploy checker to operate upon
-* Run bundle install
-* Run bundle exec rake db:generate RAILS_ENV=development
+* Run `bundle install`
+* Run `VALIDATE_SETTINGS=false bundle exec rake db:setup RAILS_ENV=development`
 * Get OAuth credentials for your JIRA instance. There are some instructions here: https://github.com/nburwell/jira-glue
 * Create a data/config/settings.development.yml file (See Settings File section below.)
-* Configure secrets in the environment:
+* Configure secrets, via environment variables of the following names:
     * GITHUB_USER_NAME: GitHub credentials. Recommend creating a personal access token that has "repo:status" scope.
     * GITHUB_PASSWORD
     * JIRA_SITE: Full URL for JIRA instance

--- a/app/controllers/jira/status/push_controller.rb
+++ b/app/controllers/jira/status/push_controller.rb
@@ -13,7 +13,6 @@ module Jira
           JiraIssuesAndPushes::ERROR_NO_DEPLOY_DATE.to_s => 'JIRA issue(s) with no deploy date',
           JiraIssuesAndPushes::ERROR_POST_DEPLOY_CHECK_STATUS.to_s =>
             'JIRA issue(s) with the wrong post deploy check status',
-          JiraIssuesAndPushes::ERROR_BLANK_SECRETS_MODIFIED.to_s => 'JIRA issue(s) with blank secrets fields',
           JiraIssuesAndPushes::ERROR_BLANK_LONG_RUNNING_MIGRATION.to_s => 'JIRA issue(s) with blank migration fields'
         }
       }.freeze
@@ -28,7 +27,6 @@ module Jira
           JiraIssuesAndPushes::ERROR_WRONG_DEPLOY_DATE.to_s => 'The deploy date in the past',
           JiraIssuesAndPushes::ERROR_NO_DEPLOY_DATE.to_s => 'Has no deploy date',
           JiraIssuesAndPushes::ERROR_POST_DEPLOY_CHECK_STATUS.to_s => 'Wrong post deploy check status',
-          JiraIssuesAndPushes::ERROR_BLANK_SECRETS_MODIFIED.to_s => 'Secrets field is blank',
           JiraIssuesAndPushes::ERROR_BLANK_LONG_RUNNING_MIGRATION.to_s => 'Migrations field is blank'
         }
       }.freeze
@@ -106,13 +104,6 @@ module Jira
         reps.sort_by { |name, _| name }
       end
       helper_method :deploy_reps
-
-      def any_secrets_modified?
-        @push.jira_issues_and_pushes.any? do |issue_and_push|
-          issue_and_push.jira_issue.secrets_modified?
-        end
-      end
-      helper_method :any_secrets_modified?
 
       def map_error_code_to_message(error_object, error_code)
         ERROR_CODE_PLURAL_MAP[error_object][error_code]

--- a/app/models/jira_issue.rb
+++ b/app/models/jira_issue.rb
@@ -9,7 +9,7 @@ class JiraIssue < ActiveRecord::Base
     targeted_deploy_date :date, null: true
     post_deploy_check_status :text, limit: 255, null: true
     deploy_type :text, limit: 255, null: true
-    secrets_modified :text, limit: 255, null: true
+    secrets_modified :text, limit: 255, null: true          # deprecated
     long_running_migration :text, limit: 255, null: true
     timestamps
   end
@@ -26,10 +26,6 @@ class JiraIssue < ActiveRecord::Base
 
   def commits_for_push(push)
     commits.joins(:commits_and_pushes).where('commits_and_pushes.push_id = ?', push.id)
-  end
-
-  def secrets_modified?
-    secrets_modified && secrets_modified == 'Yes'
   end
 
   def long_running_migration?
@@ -59,7 +55,6 @@ class JiraIssue < ActiveRecord::Base
       issue.targeted_deploy_date = extract_custom_date_field_from_jira_data(jira_data, 10600)
       issue.post_deploy_check_status = extract_custom_select_field_from_jira_data(jira_data, 12202)
       issue.deploy_type = extract_custom_multi_select_field_from_jira_data(jira_data, 12501)
-      issue.secrets_modified = extract_custom_multi_select_field_from_jira_data(jira_data, 13528)
       issue.long_running_migration = extract_custom_multi_select_field_from_jira_data(jira_data, 10601)
 
       if jira_data.assignee

--- a/app/models/jira_issue.rb
+++ b/app/models/jira_issue.rb
@@ -9,7 +9,7 @@ class JiraIssue < ActiveRecord::Base
     targeted_deploy_date :date, null: true
     post_deploy_check_status :text, limit: 255, null: true
     deploy_type :text, limit: 255, null: true
-    secrets_modified :text, limit: 255, null: true          # deprecated
+    secrets_modified :text, limit: 255, null: true # deprecated
     long_running_migration :text, limit: 255, null: true
     timestamps
   end

--- a/app/models/jira_issues_and_pushes.rb
+++ b/app/models/jira_issues_and_pushes.rb
@@ -6,7 +6,6 @@ class JiraIssuesAndPushes < ActiveRecord::Base
   ERROR_NO_COMMITS = 'no_commits'.freeze
   ERROR_WRONG_DEPLOY_DATE = 'wrong_deploy_date'.freeze
   ERROR_NO_DEPLOY_DATE = 'no_deploy_date'.freeze
-  ERROR_BLANK_SECRETS_MODIFIED = 'blank_secrets_modified'.freeze
   ERROR_BLANK_LONG_RUNNING_MIGRATION = 'blank_long_running_migration'.freeze
 
   fields do

--- a/app/models/push.rb
+++ b/app/models/push.rb
@@ -73,10 +73,6 @@ class Push < ActiveRecord::Base
     jira_issues.map(&:deploy_types).flatten.uniq
   end
 
-  def secrets_modified?
-    unmerged_jira_issues.any?(&:secrets_modified?)
-  end
-
   def long_migration?
     unmerged_jira_issues.any?(&:long_running_migration?)
   end

--- a/app/views/jira/status/push/_branch_issues.html.erb
+++ b/app/views/jira/status/push/_branch_issues.html.erb
@@ -35,7 +35,6 @@
         { title: "JIRA Status" },
         { title: "Post Deploy</br>Check Status" },
         { title: "Deploy Date" },
-        { title: "Secrets?" },
         { title: "Long</br>Migration?" },
         { title: "Summary" }
       ]

--- a/app/views/jira/status/push/_branch_issues.html.erb
+++ b/app/views/jira/status/push/_branch_issues.html.erb
@@ -87,7 +87,6 @@
       <td nowrap class="<%=error_class_if_error_present(jira_issue_and_push, [JiraIssuesAndPushes::ERROR_WRONG_STATE])%>"><%=jira_issue.status%></td>
       <td nowrap class="<%=error_class_if_error_present(jira_issue_and_push, [JiraIssuesAndPushes::ERROR_POST_DEPLOY_CHECK_STATUS])%>"><%=jira_issue.post_deploy_check_status || '&mdash;'.html_safe%></td>
       <td nowrap class="<%=error_class_if_error_present(jira_issue_and_push, [JiraIssuesAndPushes::ERROR_WRONG_DEPLOY_DATE, JiraIssuesAndPushes::ERROR_NO_DEPLOY_DATE])%>"><%=jira_issue.targeted_deploy_date || '&mdash;'.html_safe%></td>
-      <td nowrap class="<%=error_class_if_error_present(jira_issue_and_push, [JiraIssuesAndPushes::ERROR_BLANK_SECRETS_MODIFIED])%>"><%=jira_issue.secrets_modified || '&mdash;'.html_safe%></td>
       <td nowrap class="<%=error_class_if_error_present(jira_issue_and_push, [JiraIssuesAndPushes::ERROR_BLANK_LONG_RUNNING_MIGRATION])%>"><%=jira_issue.long_running_migration || '&mdash;'.html_safe%></td>
       <td class="issue_summary"><%=jira_issue.summary%></td>
     </tr>

--- a/app/views/jira/status/push/summary.html.erb
+++ b/app/views/jira/status/push/summary.html.erb
@@ -10,15 +10,14 @@
       <div class="col-md-8">
         <div class="row summary-tile-container">
           <%= render partial: "jira/status/push/summary_tiles/issue_count"%>
-          <%= render partial: "jira/status/push/summary_tiles/secrets",        locals: { push: @push } %>
           <%= render partial: "jira/status/push/summary_tiles/long_migration", locals: { push: @push } %>
+          <%= render partial: "jira/status/push/summary_tiles/deploy_types", locals: { deploy_types: @push.deploy_types } %>
         </div>
         <div class="summary-tile-container">
           <%= render partial: "jira/status/push/summary_tiles/tickets", locals: { issues: @push.sorted_jira_issues } %>
         </div>
       </div>
       <div class="col-md-4">
-        <%= render partial: "jira/status/push/summary_tiles/deploy_types", locals: { deploy_types: @push.deploy_types } %>
         <%= render partial: "jira/status/push/summary_tiles/committers" %>
       </div>
     </div>
@@ -41,14 +40,6 @@
           </td>
           <td>
             <%= deploy_reps.map { |(rep, count)| "#{count}: #{rep}" }.join("<br>").html_safe %>
-          </td>
-        </tr>
-        <tr class=<%= any_secrets_modified? ? "danger" : "success" %>>
-          <td>
-            Secrets modified
-          </td>
-          <td>
-            <%= any_secrets_modified?.to_s.capitalize %>
           </td>
         </tr>
       </table>

--- a/app/views/jira/status/push/summary_tiles/_deploy_types.html.erb
+++ b/app/views/jira/status/push/summary_tiles/_deploy_types.html.erb
@@ -1,3 +1,1 @@
-<div class="row">
-  <%= render partial: "jira/status/push/summary_tiles/base_tile", locals: { title: "Deploy Types", value: deploy_types.join("<br>").html_safe, errors: false, warning: false, col_width: "col-md-12" } %>
-</div>
+<%= render partial: "jira/status/push/summary_tiles/base_tile", locals: { title: "Deploy Types", value: deploy_types.join("<br>").html_safe, errors: false, warning: false } %>

--- a/app/views/jira/status/push/summary_tiles/_secrets.html.erb
+++ b/app/views/jira/status/push/summary_tiles/_secrets.html.erb
@@ -1,1 +1,0 @@
-<%= render partial: "jira/status/push/summary_tiles/base_tile", locals: { title: "Secrets Modified", value: push.secrets_modified? ? "Yes" : "No", success: true, errors: false, warning: push.secrets_modified? } %>

--- a/lib/push_manager.rb
+++ b/lib/push_manager.rb
@@ -144,10 +144,6 @@ class PushManager
           errors << JiraIssuesAndPushes::ERROR_NO_DEPLOY_DATE
         end
 
-        unless jira_issue.secrets_modified
-          errors << JiraIssuesAndPushes::ERROR_BLANK_SECRETS_MODIFIED
-        end
-
         unless jira_issue.long_running_migration
           errors << JiraIssuesAndPushes::ERROR_BLANK_LONG_RUNNING_MIGRATION
         end

--- a/spec/lib/push_manager_spec.rb
+++ b/spec/lib/push_manager_spec.rb
@@ -16,7 +16,6 @@ describe 'PushManager' do
                                     status: 'Ready to Deploy',
                                     targeted_deploy_date: Time.current.tomorrow,
                                     post_deploy_check_status: 'Ready to Run',
-                                    secrets_modified: 'No',
                                     long_running_migration: 'No')
     response = create_test_jira_issue_json(
       key: key,
@@ -24,7 +23,6 @@ describe 'PushManager' do
       status: status,
       targeted_deploy_date: targeted_deploy_date,
       post_deploy_check_status: post_deploy_check_status,
-      secrets_modified: secrets_modified,
       long_running_migration: long_running_migration
     )
     stub_request(:get, /\/rest\/api\/2\/issue\/#{key}/).to_return(status: 200, body: response.to_json)
@@ -98,13 +96,6 @@ describe 'PushManager' do
           match_array([JiraIssuesAndPushes::ERROR_WRONG_DEPLOY_DATE])
       end
 
-      it 'with a blank secrets field' do
-        mock_jira_find_issue_response('STORY-1234', secrets_modified: nil)
-        push = PushManager.process_push!(Push.create_from_github_data!(payload))
-        expect(push.jira_issues_and_pushes.first.error_list).to \
-          match_array([JiraIssuesAndPushes::ERROR_BLANK_SECRETS_MODIFIED])
-      end
-
       it 'with a blank migration field' do
         mock_jira_find_issue_response('STORY-1234', long_running_migration: nil)
         push = PushManager.process_push!(Push.create_from_github_data!(payload))
@@ -127,7 +118,6 @@ describe 'PushManager' do
           status: 'Wrong State',
           post_deploy_check_status: nil,
           targeted_deploy_date: nil,
-          secrets_modified: nil,
           long_running_migration: nil
         )
         push = PushManager.process_push!(Push.create_from_github_data!(payload))
@@ -145,7 +135,6 @@ describe 'PushManager' do
           status: 'Closed',
           post_deploy_check_status: nil,
           targeted_deploy_date: nil,
-          secrets_modified: nil,
           long_running_migration: nil
         )
         push = PushManager.process_push!(Push.create_from_github_data!(payload))

--- a/spec/models/jira_issue_spec.rb
+++ b/spec/models/jira_issue_spec.rb
@@ -17,7 +17,6 @@ describe 'JiraIssue' do
     expect(issue.targeted_deploy_date).to eq(Date.parse('2016-09-21'))
     expect(issue.post_deploy_check_status).to eq('Ready to Run')
     expect(issue.deploy_type).to eq('Web, PNAPI')
-    expect(issue.secrets_modified).to eq('No')
     expect(issue.long_running_migration).to eq('No')
 
     expect(issue.parent_issue).to be_nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,7 +63,6 @@ def create_test_jira_issue_json(key: nil,
                                 post_deploy_check_status: 'Ready to Run',
                                 deploy_type: nil,
                                 parent_key: nil,
-                                secrets_modified: 'No',
                                 long_running_migration: 'No')
   json = if parent_key
            load_json_fixture('jira_sub_task_response')
@@ -97,12 +96,6 @@ def create_test_jira_issue_json(key: nil,
 
     if deploy_type
       json['fields']['customfield_12501'][0]['value'] = deploy_type
-    end
-
-    if secrets_modified
-      json['fields']['customfield_13528'][0]['value'] = secrets_modified
-    else
-      json['fields'].except!('customfield_13528')
     end
 
     if long_running_migration


### PR DESCRIPTION
* Removes the secrets check from PDC as well as the tile on the summary page
* Moved the "deploy types" tile over in its place, and moved "committers" box up, and will automatically fill the right column as needed:
![summary-page](https://user-images.githubusercontent.com/372310/48788362-862f4480-ec9f-11e8-8160-ea8e2df547b9.png)

This is in conjunction with removing the "secrets added" custom field from our JIRA workflow screens.