### PR TITLE
Remove Jira deploy date check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 
 gem 'bootstrap-sass'
 
-gem 'nokogiri', '1.10.3'
+gem 'nokogiri', '1.10.5'
 
 group :test do
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,7 @@ GEM
       tins (~> 1.6)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    crass (1.0.4)
+    crass (1.0.6)
     daemons (1.2.4)
     database_cleaner (1.5.3)
     debug_inspector (0.0.2)
@@ -138,7 +138,7 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.8.6)
     kgio (2.11.0)
-    loofah (2.2.3)
+    loofah (2.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -178,7 +178,7 @@ GEM
     mutant-rspec (0.8.11)
       mutant (~> 0.8.11)
       rspec-core (>= 3.4.0, < 3.6.0)
-    nokogiri (1.10.3)
+    nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
     oauth (0.4.7)
     parallel (1.12.1)
@@ -190,7 +190,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (2.0.5)
-    rack (1.6.11)
+    rack (1.6.12)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.11.1)
@@ -350,7 +350,7 @@ DEPENDENCIES
   jira-ruby (= 0.1.17)
   jquery-rails
   mutant-rspec
-  nokogiri (= 1.10.3)
+  nokogiri (= 1.10.5)
   pry
   rails (= 4.2.11.1)
   rspec
@@ -370,4 +370,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/app/controllers/jira/status/push_controller.rb
+++ b/app/controllers/jira/status/push_controller.rb
@@ -9,8 +9,6 @@ module Jira
         'jira_issue' => {
           JiraIssuesAndPushes::ERROR_WRONG_STATE.to_s => 'JIRA issue(s) in the wrong state',
           JiraIssuesAndPushes::ERROR_NO_COMMITS.to_s => 'JIRA issue(s) with no commits',
-          JiraIssuesAndPushes::ERROR_WRONG_DEPLOY_DATE.to_s => 'JIRA issue(s) with a deploy date in the past',
-          JiraIssuesAndPushes::ERROR_NO_DEPLOY_DATE.to_s => 'JIRA issue(s) with no deploy date',
           JiraIssuesAndPushes::ERROR_POST_DEPLOY_CHECK_STATUS.to_s =>
             'JIRA issue(s) with the wrong post deploy check status',
           JiraIssuesAndPushes::ERROR_BLANK_LONG_RUNNING_MIGRATION.to_s => 'JIRA issue(s) with blank migration fields'
@@ -24,8 +22,6 @@ module Jira
         'jira_issue' => {
           JiraIssuesAndPushes::ERROR_WRONG_STATE.to_s => 'In the wrong state',
           JiraIssuesAndPushes::ERROR_NO_COMMITS.to_s => 'Has no commits',
-          JiraIssuesAndPushes::ERROR_WRONG_DEPLOY_DATE.to_s => 'The deploy date in the past',
-          JiraIssuesAndPushes::ERROR_NO_DEPLOY_DATE.to_s => 'Has no deploy date',
           JiraIssuesAndPushes::ERROR_POST_DEPLOY_CHECK_STATUS.to_s => 'Wrong post deploy check status',
           JiraIssuesAndPushes::ERROR_BLANK_LONG_RUNNING_MIGRATION.to_s => 'Migrations field is blank'
         }

--- a/app/models/jira_issue.rb
+++ b/app/models/jira_issue.rb
@@ -6,7 +6,7 @@ class JiraIssue < ActiveRecord::Base
     issue_type :text, limit: 255, null: false
     summary :text, limit: 1024, null: false
     status :text, limit: 255, null: false
-    targeted_deploy_date :date, null: true
+    targeted_deploy_date :date, null: true # Custom Data Field: 10600
     post_deploy_check_status :text, limit: 255, null: true
     deploy_type :text, limit: 255, null: true
     secrets_modified :text, limit: 255, null: true # deprecated
@@ -52,7 +52,6 @@ class JiraIssue < ActiveRecord::Base
       issue.summary = jira_data.summary.truncate(1024)
       issue.issue_type = jira_data.issuetype.name
       issue.status = jira_data.fields['status']['name']
-      issue.targeted_deploy_date = extract_custom_date_field_from_jira_data(jira_data, 10600)
       issue.post_deploy_check_status = extract_custom_select_field_from_jira_data(jira_data, 12202)
       issue.deploy_type = extract_custom_multi_select_field_from_jira_data(jira_data, 12501)
       issue.long_running_migration = extract_custom_multi_select_field_from_jira_data(jira_data, 10601)

--- a/app/models/jira_issues_and_pushes.rb
+++ b/app/models/jira_issues_and_pushes.rb
@@ -4,8 +4,6 @@ class JiraIssuesAndPushes < ActiveRecord::Base
   ERROR_WRONG_STATE = 'wrong_state'.freeze
   ERROR_POST_DEPLOY_CHECK_STATUS = 'wrong_post_deploy_status'.freeze
   ERROR_NO_COMMITS = 'no_commits'.freeze
-  ERROR_WRONG_DEPLOY_DATE = 'wrong_deploy_date'.freeze
-  ERROR_NO_DEPLOY_DATE = 'no_deploy_date'.freeze
   ERROR_BLANK_LONG_RUNNING_MIGRATION = 'blank_long_running_migration'.freeze
 
   fields do

--- a/app/views/jira/status/push/_branch_issues.html.erb
+++ b/app/views/jira/status/push/_branch_issues.html.erb
@@ -85,7 +85,6 @@
       <td nowrap><%=jira_issue.deploy_type%></td>
       <td nowrap class="<%=error_class_if_error_present(jira_issue_and_push, [JiraIssuesAndPushes::ERROR_WRONG_STATE])%>"><%=jira_issue.status%></td>
       <td nowrap class="<%=error_class_if_error_present(jira_issue_and_push, [JiraIssuesAndPushes::ERROR_POST_DEPLOY_CHECK_STATUS])%>"><%=jira_issue.post_deploy_check_status || '&mdash;'.html_safe%></td>
-      <td nowrap class="<%=error_class_if_error_present(jira_issue_and_push, [JiraIssuesAndPushes::ERROR_WRONG_DEPLOY_DATE, JiraIssuesAndPushes::ERROR_NO_DEPLOY_DATE])%>"><%=jira_issue.targeted_deploy_date || '&mdash;'.html_safe%></td>
       <td nowrap class="<%=error_class_if_error_present(jira_issue_and_push, [JiraIssuesAndPushes::ERROR_BLANK_LONG_RUNNING_MIGRATION])%>"><%=jira_issue.long_running_migration || '&mdash;'.html_safe%></td>
       <td class="issue_summary"><%=jira_issue.summary%></td>
     </tr>

--- a/lib/push_manager.rb
+++ b/lib/push_manager.rb
@@ -136,14 +136,6 @@ class PushManager
           errors << JiraIssuesAndPushes::ERROR_NO_COMMITS
         end
 
-        if jira_issue.targeted_deploy_date
-          if jira_issue.targeted_deploy_date.to_date < Time.zone.today
-            errors << JiraIssuesAndPushes::ERROR_WRONG_DEPLOY_DATE
-          end
-        else
-          errors << JiraIssuesAndPushes::ERROR_NO_DEPLOY_DATE
-        end
-
         unless jira_issue.long_running_migration
           errors << JiraIssuesAndPushes::ERROR_BLANK_LONG_RUNNING_MIGRATION
         end

--- a/spec/models/jira_issue_spec.rb
+++ b/spec/models/jira_issue_spec.rb
@@ -14,7 +14,6 @@ describe 'JiraIssue' do
     expect(issue.summary).to eq('This is the issue summary')
     expect(issue.issue_type).to eq('Story')
     expect(issue.status).to eq('Code Review')
-    expect(issue.targeted_deploy_date).to eq(Date.parse('2016-09-21'))
     expect(issue.post_deploy_check_status).to eq('Ready to Run')
     expect(issue.deploy_type).to eq('Web, PNAPI')
     expect(issue.long_running_migration).to eq('No')

--- a/spec/models/jira_issues_and_pushes_spec.rb
+++ b/spec/models/jira_issues_and_pushes_spec.rb
@@ -123,15 +123,15 @@ describe 'JiraIssuesAndPushes' do
 
   context 'with_unignored_errors scope' do
     it 'can find pushes with errors' do
-      JiraIssuesAndPushes.create_or_update!(@issue, @push, [JiraIssuesAndPushes::ERROR_WRONG_DEPLOY_DATE])
+      JiraIssuesAndPushes.create_or_update!(@issue, @push, [JiraIssuesAndPushes::ERROR_WRONG_STATE])
       @issue.reload
       expect(@issue.jira_issues_and_pushes.with_unignored_errors.count).to eq(1)
       expect(JiraIssuesAndPushes.get_error_counts_for_push(@push)).to \
-        eq(JiraIssuesAndPushes::ERROR_WRONG_DEPLOY_DATE => 1)
+        eq(JiraIssuesAndPushes::ERROR_WRONG_STATE => 1)
     end
 
     it 'excludes pushes with ignored errors' do
-      record = JiraIssuesAndPushes.create_or_update!(@issue, @push, [JiraIssuesAndPushes::ERROR_WRONG_DEPLOY_DATE])
+      record = JiraIssuesAndPushes.create_or_update!(@issue, @push, [JiraIssuesAndPushes::ERROR_WRONG_STATE])
       record.ignore_errors = true
       record.save!
       @issue.reload

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,7 +59,6 @@ end
 
 def create_test_jira_issue_json(key: nil,
                                 status: nil,
-                                targeted_deploy_date: Time.current.tomorrow,
                                 post_deploy_check_status: 'Ready to Run',
                                 deploy_type: nil,
                                 parent_key: nil,
@@ -82,12 +81,6 @@ def create_test_jira_issue_json(key: nil,
     json['fields']['parent']['key'] = parent_key
   else
     # these fields are only valid for non-sub-tasks
-    if targeted_deploy_date
-      json['fields']['customfield_10600'] = targeted_deploy_date.to_time.iso8601
-    else
-      json['fields'].except!('customfield_10600')
-    end
-
     if post_deploy_check_status
       json['fields']['customfield_12202']['value'] = post_deploy_check_status
     else
@@ -110,7 +103,6 @@ end
 
 def create_test_jira_issue(key: nil,
                            status: nil,
-                           targeted_deploy_date: Time.current.tomorrow,
                            post_deploy_check_status: nil,
                            deploy_type: nil,
                            parent_key: nil)
@@ -119,7 +111,6 @@ def create_test_jira_issue(key: nil,
       create_test_jira_issue_json(
         key: key,
         status: status,
-        targeted_deploy_date: targeted_deploy_date,
         post_deploy_check_status: post_deploy_check_status,
         deploy_type: deploy_type,
         parent_key: parent_key


### PR DESCRIPTION
With discussion from Colin and Nick, we are deciding to not worry about
deploy date in PreDeployChecker. The ideal state would be to have the
deploy_date automatically set in Jira when moving a ticket from Ready To
Deploy to PostDeploy/Closed. It was deemed that the removal of the check
can  be worked before the automation of this is complete