### PR TITLE
Utilize displayName to generate fake email

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,19 @@
 class User < ActiveRecord::Base
   include GitModels::User
 
-  def self.create_from_jira_data!(jira_user_data)
-    # JIRA removed emailAddress from their API so we create a fake one here. It is only used to guarantee uniqueness
-    User.where(name: jira_user_data.displayName, email: "#{jira_user_data.name}@email.com").first_or_create!
+  class << self
+    def create_from_jira_data!(jira_user_data)
+      # Uses fake email to guarantee uniqueness
+      name = jira_user_data.displayName
+      User.where(name: name, email: fake_email_from_name(name)).first_or_create!
+    end
+
+    private
+
+    # Converts (First Last) => flast@email.com
+    def fake_email_from_name(display_name)
+      name_arr = display_name.downcase.split(' ')
+      "#{name_arr.first.first}#{name_arr.last}@email.com"
+    end
   end
 end

--- a/spec/models/jira_issue_spec.rb
+++ b/spec/models/jira_issue_spec.rb
@@ -65,14 +65,13 @@ describe 'JiraIssue' do
     it 'can be changed' do
       orginal_issue = JiraIssue.create_from_jira_data!(jira_issue)
 
-      jira_issue.assignee.attrs['name'] = 'otheruser'
       jira_issue.assignee.attrs['displayName'] = 'Other User'
 
       updated_issue = JiraIssue.create_from_jira_data!(jira_issue)
 
       expect(User.count).to eq(2)
       expect(orginal_issue.assignee.id).not_to eq(updated_issue.assignee.id)
-      expect(updated_issue.assignee.email).to eq('otheruser@email.com')
+      expect(updated_issue.assignee.email).to eq('ouser@email.com')
     end
   end
 


### PR DESCRIPTION
Jira has removed the `name` attribute from the assignee for an issue.
```ruby
jira_client.find_issue_by_key(JiraIssue.last.key).assignee.name
NoMethodError: undefined method `name' for #<JIRA::Resource::User:0x00000000051e1e28>
	from /usr/local/bundle/gems/jira-ruby-0.1.17/lib/jira/base.rb:308:in `method_missing'
	from (irb):64
	from /usr/local/bundle/gems/railties-4.2.11.1/lib/rails/commands/console.rb:110:in `start'
	from /usr/local/bundle/gems/railties-4.2.11.1/lib/rails/commands/console.rb:9:in `start'
	from /usr/local/bundle/gems/railties-4.2.11.1/lib/rails/commands/commands_tasks.rb:68:in `console'
	from /usr/local/bundle/gems/railties-4.2.11.1/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
	from /usr/local/bundle/gems/railties-4.2.11.1/lib/rails/commands.rb:17:in `<top (required)>'
	from bin/rails:8:in `require'
	from bin/rails:8:in `<main>'
```
We only used this field to keep uniqueness with the User model so we can just utilize the display name instead.