### PR TITLE
no-jira: explicitly use Pacific Time

### DIFF
--- a/app/mailers/deploy_mailer.rb
+++ b/app/mailers/deploy_mailer.rb
@@ -10,6 +10,7 @@ class DeployMailer < ApplicationMailer
 
   def deployment_email(jira_issues)
     @jira_issues = jira_issues
-    mail(to: 'deploy@invoca.com', subject: "Web Deploy #{Time.now.strftime('%m/%d/%y %H:%M %z')}")
+    now = Time.now.in_time_zone('Pacific Time (US & Canada)') # since `config.time_zone =` not working
+    mail(to: 'deploy@invoca.com', subject: "Web Deploy #{now.strftime('%m/%d/%y %H:%M %z')}")
   end
 end

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -4,4 +4,4 @@
 # Rails.backtrace_cleaner.add_silencer { |line| line =~ /my_noisy_library/ }
 
 # You can also remove all the silencers if you're trying to debug a problem that might stem from framework code.
-# Rails.backtrace_cleaner.remove_silencers!
+Rails.backtrace_cleaner.remove_silencers!

--- a/spec/controllers/jira/status/push_controller_spec.rb
+++ b/spec/controllers/jira/status/push_controller_spec.rb
@@ -20,6 +20,7 @@ describe Jira::Status::PushController, type: :controller do
     end
 
     it 'sends an email and returns success for push' do
+      allow(Time).to receive(:now).and_return(Time.gm(2020, 7, 4, 12, 0))
       get :deploy_email, id: '12345678'
       expect(response).to have_http_status(302)
       expect(flash[:alert]).to match(/Email has been sent/)
@@ -27,8 +28,7 @@ describe Jira::Status::PushController, type: :controller do
       sent_email = DeployEmailInterceptor.intercepted_email
       expect(sent_email.to).to eq ['deploy@invoca.com']
       expect(sent_email.from).to eq ['deploy@invoca.com']
-      expect(Time.zone.name).to eq("Pacific Time (US & Canada)")
-      expect(sent_email.subject).to include("Web Deploy #{Time.now.strftime('%m/%d/%y %H:%M %z')}")
+      expect(sent_email.subject).to eq("Web Deploy 07/04/20 05:00 -0700")
       expect(@push.reload.email_sent).to eq(true)
     end
 


### PR DESCRIPTION
I'm not sure why the config in application.rb wasn't sticking, but this fixes it.