### PR TITLE
No-Jira: move build from Semaphore to Jenkins

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
       parallel {
         stage('Unit Tests') {
           steps { sh 'bundle exec rspec' }
-          post { always { junit 'spec/report/*.xml' } }
+          post { always { junit 'spec/reports/*.xml' } }
         }
 
         stage('Coveralls') {

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -33,6 +33,7 @@ pipeline {
   stages {
     stage('Setup') {
       steps {
+        sh 'apt-get update && apt-get install -y nodejs'
         sh 'bundle install'
         sh 'bundle exec rake db:setup'
         sh 'bundle exec rake db:test:prepare'

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -1,0 +1,94 @@
+#!/usr/bin/groovy
+@Library('jenkins-pipeline@v0.4.5')
+import com.invoca.docker.*;
+
+def setGitHubStatus(String name, String status, String description) {
+  gitHubStatus([
+    repoSlug:    'Invoca/pre_deploy_checker',
+    sha:         env.GIT_COMMIT,
+    description: description,
+    context:     name,
+    targetURL:   env.RUN_DISPLAY_URL,
+    token:       env.GITHUB_TOKEN,
+    status:      status
+  ])
+}
+
+pipeline {
+  agent {
+    kubernetes {
+      yamlFile '.jenkins/build_pod.yml'
+      defaultContainer 'ruby'
+    }
+  }
+
+  environment {
+    BUNDLE_GEM__FURY__IO    = credentials('gemfury_deploy_token')
+    DOCKERHUB_USER          = credentials('dockerhub_user')
+    DOCKERHUB_PASSWORD      = credentials('dockerhub_password')
+    GITHUB_TOKEN            = credentials('github_token')
+    RAILS_ENV               = 'test'
+  }
+
+  stages {
+    stage('Setup') {
+      steps {
+        sh 'bundle install'
+        sh 'bundle exec rake db:setup'
+        sh 'bundle exec rake db:test:prepare'
+        container('docker') {
+          script {
+            new Docker().hubLogin(env.DOCKERHUB_USER, env.DOCKERHUB_PASSWORD)
+            def tags = [env.GIT_COMMIT, env.GIT_BRANCH]
+            prodImage = new Image(this, "invocaops/pre_deploy_checker", tags)
+          }
+        }
+      }
+    }
+
+    stage('Tests') {
+      parallel {
+        stage('Unit Tests') {
+          steps { sh 'bundle exec rspec' }
+          post { always { junit 'spec/report/*.xml' } }
+        }
+
+        stage('Coveralls') {
+          steps { sh 'bundle exec rake coveralls:push' }
+        }
+
+        stage('Breakman') {
+          steps { sh 'bundle exec brakeman -z' }
+        }
+
+        stage('CVE Check') {
+          steps {
+            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+              sh 'bundle exec bundle-audit check --update --ignore CVE-2020-8184 CVE-2020-8161 CVE-2020-10663 CVE-2020-8165CVE-2020-5267 CVE-2020-8167 CVE-2020-8166 CVE-2020-8164 CVE-2020-5267 CVE-2020-8165'
+            }
+          }
+        }
+      }
+    }
+
+    stage('Build Image') {
+      steps {
+        container('docker') {
+          script {
+            prodImage.build(
+              gitUrl: env.GIT_URL,
+              buildArgs: [
+                "BUNDLE_GEM__FURY__IO": env.BUNDLE_GEM__FURY__IO,
+                "RAILS_ENV":            'production'
+              ]
+            ).tag()
+          }
+        }
+      }
+    }
+
+    stage('Push Image') {
+      steps { container('docker') { script { prodImage.push() } } }
+    }
+  }
+}

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -33,6 +33,7 @@ pipeline {
   stages {
     stage('Setup') {
       steps {
+        setGitHubStatus('clean-build', 'pending', 'Running unit tests...')
         sh 'apt-get update && apt-get install -y nodejs'
         sh 'bundle install'
         sh 'bundle exec rake db:setup'
@@ -45,13 +46,18 @@ pipeline {
           }
         }
       }
+      post { failure { setGitHubStatus('clean-build', 'failure', 'Build setup failed.') } }
     }
 
     stage('Tests') {
       parallel {
         stage('Unit Tests') {
           steps { sh 'bundle exec rspec' }
-          post { always { junit 'spec/reports/*.xml' } }
+          post {
+            success { setGitHubStatus('clean-build', 'success', 'All tests passed!') }
+            failure { setGitHubStatus('clean-build', 'failure', 'Failures in unit tests.') }
+            always { junit 'spec/reports/*.xml' }
+          }
         }
 
         stage('Coveralls') {
@@ -68,12 +74,17 @@ pipeline {
               sh 'bundle exec bundle-audit check --update --ignore CVE-2020-8184 CVE-2020-8161 CVE-2020-10663 CVE-2020-8165CVE-2020-5267 CVE-2020-8167 CVE-2020-8166 CVE-2020-8164 CVE-2020-5267 CVE-2020-8165'
             }
           }
+          post {
+            success { setGitHubStatus('cve-audit', 'success', 'No vulnerabilities detected.') }
+            failure { setGitHubStatus('cve-audit', 'failure', 'Found vulnerabilities!') }
+          }
         }
       }
     }
 
     stage('Build Image') {
       steps {
+        setGitHubStatus('image-build', 'pending', 'Building docker image...')
         container('docker') {
           script {
             prodImage.build(
@@ -86,10 +97,17 @@ pipeline {
           }
         }
       }
+      post {
+        failure { setGitHubStatus('image-build', 'failed', 'Docker image failed to build') }
+      }
     }
 
     stage('Push Image') {
       steps { container('docker') { script { prodImage.push() } } }
+      post {
+        success { setGitHubStatus('image-build', 'success', 'Docker image built and pushed to dockerhub') }
+        failure { setGitHubStatus('image-build', 'failed', 'Docker image failed to push to dockerhub') }
+      }
     }
   }
 }

--- a/.jenkins/build_pod.yml
+++ b/.jenkins/build_pod.yml
@@ -1,0 +1,48 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    jenkins/pre_deploy_checker: 'true'
+  namespace: jenkins
+  name: pre_deploy_checker
+spec:
+  tolerations:
+  - key: dedicated
+    operator: Equal
+    value: jenkins
+    effect: NoSchedule
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: kops.k8s.io/instancegroup
+            operator: In
+            values:
+            - jenkins
+  containers:
+  - name: ruby
+    image: ruby:2.4.2
+    tty: true
+    resources:
+      requests:
+        memory: "100Mi"
+    command:
+    - cat
+  - name: docker
+    image: docker:19.03.8
+    tty: true
+    resources:
+      requests:
+        memory: "512Mi"
+    command:
+    - cat
+    volumeMounts:
+    - name: docker-sock
+      mountPath: /var/run/docker.sock
+  volumes:
+  - name: docker-sock
+    hostPath:
+      path: /var/run/docker.sock
+      type: Socket

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--require spec_helper
+--format progress
+--color

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :test do
   gem 'timecop'
   gem 'coveralls', '~> 0.8.22'
   gem 'rspec'
+  gem 'rspec_junit_formatter'
   gem 'rspec-rails'
   gem 'database_cleaner'
   gem 'stub_env'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,6 +253,8 @@ GEM
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
     rspec-support (3.9.3)
+    rspec_junit_formatter (0.4.1)
+      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (0.86.0)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
@@ -370,6 +372,7 @@ DEPENDENCIES
   rails (= 4.2.11.3)
   rspec
   rspec-rails
+  rspec_junit_formatter
   rubocop
   rubocop-rspec
   sass-rails (~> 5.0)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 ENV['RAILS_ENV'] ||= 'test'
 require 'coveralls'
+require 'rspec_junit_formatter'
 Coveralls.wear!('rails') if ENV['CI'] == 'true'
 require_relative '../config/environment'
 require 'rails/test_help'
@@ -19,6 +20,8 @@ require 'helpers/deploy_email_interceptor'
 GitConflictDetector::Application.load_tasks
 
 RSpec.configure do |config|
+  config.add_formatter(RspecJunitFormatter, 'spec/reports/rspec.xml')
+
   config.include StubEnv::Helpers
 
   config.before(:suite) do


### PR DESCRIPTION
This PR is moving the entire build process for the PreDeployChecker service over to Jenkins from Semaphore in an effort to migrate completely off of Semaphore.

![image](https://user-images.githubusercontent.com/571077/88419057-c89a1480-cde4-11ea-847e-54be25c261e4.png)

### Additional Notes
* After this is merged we can delete the project from Semaphore Classic
* This is also making a couple adjustments to the RSpec configuration to bring it into parity with the rest of out RSpec using services and gems
* Adds additional Github statuses so that the build does not need to stop due to CVE audit errors but instead the sha is flagged