### PR TITLE
no-jira: when some issues in a push have been deployed, remove them f…

### DIFF
--- a/app/models/jira_issues_and_pushes.rb
+++ b/app/models/jira_issues_and_pushes.rb
@@ -39,11 +39,15 @@ class JiraIssuesAndPushes < ActiveRecord::Base
     get_error_counts(with_unignored_errors.for_push(push))
   end
 
-  def self.mark_as_merged_if_jira_issue_not_in_list(push, jira_issues)
-    jira_issue_not_in_list(push, jira_issues).update_all(merged: true)
+  def self.mark_all_as_merged(push)
+    for_push(push).update_all(merged: true)
   end
 
-  def self.jira_issue_not_in_list(push, jira_issues)
+  def self.destroy_if_jira_issue_not_in_list(push, jira_issues)
+    jira_issues_not_in_list(push, jira_issues).destroy_all
+  end
+
+  def self.jira_issues_not_in_list(push, jira_issues)
     if jira_issues.any?
       for_push(push).where('jira_issue_id NOT IN (?)', jira_issues)
     else

--- a/spec/models/jira_issues_and_pushes_spec.rb
+++ b/spec/models/jira_issues_and_pushes_spec.rb
@@ -147,7 +147,7 @@ describe 'JiraIssuesAndPushes' do
     end
   end
 
-  context 'mark_as_merged_if_jira_issue_not_in_list' do
+  context 'mark_all_as_merged' do
     context 'with jira_issues' do
       before do
         JiraIssuesAndPushes.create_or_update!(@issue, @push)
@@ -156,27 +156,51 @@ describe 'JiraIssuesAndPushes' do
         @third_issue = create_test_jira_issue(key: 'WEB-5678')
         JiraIssuesAndPushes.create_or_update!(@third_issue, @push)
         expect(@push.jira_issues_and_pushes.count).to eq(3)
-        expect(@push.jira_issues_and_pushes.merged.count).to eq(0)
+        expect(@push.jira_issues_and_pushes.merged).to be_empty
       end
 
-      it 'only marks issues not in the list' do
-        JiraIssuesAndPushes.mark_as_merged_if_jira_issue_not_in_list(@push, [@second_issue])
-        expect(@push.jira_issues_and_pushes.merged.count).to eq(2)
-        expect(@push.jira_issues_and_pushes.not_merged.count).to eq(1)
-        expect(@push.jira_issues_and_pushes.not_merged.first.jira_issue).to eq(@second_issue)
-      end
-
-      it 'marks all issues if the list is empty' do
-        JiraIssuesAndPushes.mark_as_merged_if_jira_issue_not_in_list(@push, [])
+      it 'marks all issues as merged' do
+        JiraIssuesAndPushes.mark_all_as_merged(@push)
         expect(@push.jira_issues_and_pushes.merged.count).to eq(3)
         expect(@push.jira_issues_and_pushes.not_merged).to be_empty
       end
     end
 
     context 'without jira_issues' do
-      it 'does not fail if there are no issues to mark' do
+      it 'does not fail if there are no issues to mark as merged' do
         expect(@push.jira_issues_and_pushes).to be_empty
-        JiraIssuesAndPushes.mark_as_merged_if_jira_issue_not_in_list(@push, [@issue])
+        JiraIssuesAndPushes.mark_all_as_merged(@push)
+      end
+    end
+  end
+
+  context 'destroy_if_jira_issue_not_in_list' do
+    context 'with jira_issues' do
+      before do
+        JiraIssuesAndPushes.create_or_update!(@issue, @push)
+        @second_issue = create_test_jira_issue(key: 'WEB-1234')
+        JiraIssuesAndPushes.create_or_update!(@second_issue, @push)
+        @third_issue = create_test_jira_issue(key: 'WEB-5678')
+        JiraIssuesAndPushes.create_or_update!(@third_issue, @push)
+        expect(@push.jira_issues_and_pushes.count).to eq(3)
+      end
+
+      it 'only destroys issues not in the list' do
+        JiraIssuesAndPushes.destroy_if_jira_issue_not_in_list(@push, [@second_issue])
+        expect(@push.jira_issues_and_pushes.count).to eq(1)
+        expect(@push.jira_issues_and_pushes.first.jira_issue).to eq(@second_issue)
+      end
+
+      it 'destroys all issues if the list is empty' do
+        JiraIssuesAndPushes.destroy_if_jira_issue_not_in_list(@push, [])
+        expect(@push.jira_issues_and_pushes).to be_empty
+      end
+    end
+
+    context 'without jira_issues' do
+      it 'does not fail if there are no issues to destroy' do
+        expect(@push.jira_issues_and_pushes).to be_empty
+        JiraIssuesAndPushes.destroy_if_jira_issue_not_in_list(@push, [@issue])
       end
     end
   end


### PR DESCRIPTION
…rom the push

Fixing the following issue:

- Push A contains Jira Issues 1, 2, 3
- Push B contains Jira Issues 1, 2, 3, 4, 5
- Push A is deployed
- Push A still shows that it contains Jira Issues 1, 2, 3, but they are marked as "Merged" (good, because we want a record of what was deployed and we want the deploy email to work)
- Push B still shows that it contains Jira Issues 1, 2, 3, 4, 5, but 1, 2, 3 are marked as "Merged" (bad, because now that 1, 2, 3 are deployed they have nothing to do with Push B. This leads to developer confusion about what will be deployed with Push B, plus it will include Issues 1, 2, 3 in the deploy email when Push B is deployed).

New behavior will be:
- Push A contains Jira Issues 1, 2, 3
- Push B contains Jira Issues 1, 2, 3, 4, 5
- Push A is deployed
- Push A still shows that it contains Jira Issues 1, 2, 3, but they are marked as "Merged"
- Push B now shows that it only contains Jira Issues 4, 5
