### PR TITLE
Only set a github status for Pushes that are for the web service

### DIFF
--- a/lib/workers/push_change_handler.rb
+++ b/lib/workers/push_change_handler.rb
@@ -26,7 +26,7 @@ class PushChangeHandler
   private
 
   def set_status_for_push!(push) # rubocop:disable Naming/AccessorMethodName
-    if push.service.name == "web"
+    if push.service_name == "web"
       api = Github::Api::Status.new(Rails.application.secrets.github_user_name,
                                     Rails.application.secrets.github_password)
       api.set_status(push.branch.repository.name,

--- a/lib/workers/push_change_handler.rb
+++ b/lib/workers/push_change_handler.rb
@@ -26,13 +26,15 @@ class PushChangeHandler
   private
 
   def set_status_for_push!(push) # rubocop:disable Naming/AccessorMethodName
-    api = Github::Api::Status.new(Rails.application.secrets.github_user_name,
-                                  Rails.application.secrets.github_password)
-    api.set_status(push.branch.repository.name,
-                   push.head_commit.sha,
-                   CONTEXT_NAME,
-                   push.status,
-                   STATE_DESCRIPTIONS[push.status.to_sym],
-                   url_for(controller: '/jira/status/push', action: :edit, id: push.head_commit.sha))
+    if push.service.name == "web"
+      api = Github::Api::Status.new(Rails.application.secrets.github_user_name,
+                                    Rails.application.secrets.github_password)
+      api.set_status(push.branch.repository.name,
+                     push.head_commit.sha,
+                     CONTEXT_NAME,
+                     push.status,
+                     STATE_DESCRIPTIONS[push.status.to_sym],
+                     url_for(controller: '/jira/status/push', action: :edit, id: push.head_commit.sha))
+    end
   end
 end


### PR DESCRIPTION
I noticed that some Pre-deploy Checker statuses on github were marked as Failed, even though clicking on the link and stepping through to the PDC showed that it was successful. I dug in a bit and realized each commit had four Pushes, one for web and three for ringswitch. When the ringswitch Pushes were not green, they were setting the status on github as failed.

To fix that, I updated the code to only push the status if the service is "web".