### PR TITLE
no-jira: widen text columns

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -64,7 +64,7 @@ pipeline {
           steps { sh 'bundle exec rake coveralls:push' }
         }
 
-        stage('Breakman') {
+        stage('Brakeman') {
           steps { sh 'bundle exec brakeman -z' }
         }
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ source PRIVATE_GEM_SERVER
 gem 'mysql2', '~> 0.5.2'
 gem 'yaml_db'
 gem 'rails', '~> 5.2', ">= 5.2.4.4"
-gem 'sqlite3', '~> 1.3.0'
 gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails', '~> 4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,7 +316,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
     stub_env (1.0.4)
       rspec (>= 2.0, < 4.0)
     sync (0.5.0)
@@ -404,7 +403,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   spring
-  sqlite3 (~> 1.3.0)
   stub_env
   timecop
   turbolinks

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ The PDC can be triggered several ways:
 * Point the webhook at http://YOURSERVERNAME/api/v1/callbacks/github/push
 
 ## Development Environment Setup
-* Install SQLite3
 * Install bundler
 * Install rbenv
 * Install git (>= 2.6.2)

--- a/app/models/concerns/errors_json.rb
+++ b/app/models/concerns/errors_json.rb
@@ -3,7 +3,7 @@ module ErrorsJson
 
   included do
     fields do
-      errors_json :text, null: true
+      errors_json :text, limit: 0xffff_ffff, null: true
       ignore_errors :boolean, default: false, null: false
     end
 

--- a/app/models/concerns/errors_json.rb
+++ b/app/models/concerns/errors_json.rb
@@ -3,7 +3,7 @@ module ErrorsJson
 
   included do
     fields do
-      errors_json :string, limit: 256, null: true
+      errors_json :text, null: true
       ignore_errors :boolean, default: false, null: false
     end
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,16 +1,9 @@
-# MySQL version 2.x
-#   gem install mysql2
-#
-#   Ensure the MySQL 2 gem is defined in your Gemfile
-#   gem 'mysql2'
-#
-
 default: &default
   adapter: mysql2
   pool: 5
   username: <%= ENV['DATABASE_USER'] || "rr_dev" %>
   password: <%= ENV['DATABASE_PASS'] || "dev" %>
-  host: 127.0.0.1
+  host: <%= File.exist?('/tmp/mysql.sock') ? 'localhost' : '127.0.0.1' %>
 
 test:
   <<: *default

--- a/db/migrate/20201025185335_widen_text_columns.rb
+++ b/db/migrate/20201025185335_widen_text_columns.rb
@@ -1,0 +1,190 @@
+class WidenTextColumns < ActiveRecord::Migration[5.0]
+  def change
+    migrate! do
+      change_table! 'delayed_jobs' do
+        change_column! 'handler', :text, null: false do
+          up!   limit: 0xffff_ffff
+          down! limit: 0xffff
+        end
+        change_column! 'last_error', :text, null: true do
+          up!   limit: 0xffff_ffff
+          down! limit: 0xffff
+        end
+      end
+
+      change_table! 'branches' do
+        change_column! 'name', null: false do
+          up!   :string, limit: 1024
+          down! :text,   limit: 0xffff
+        end
+      end
+
+      change_table! 'commits' do
+        change_column! 'sha', limit: 255, null: false do
+          up!   :string
+          down! :text
+        end
+        change_column! 'message', :text, null: false do
+          up!   limit: 0xffff_ffff
+          down! limit: 0xffff
+        end
+      end
+
+      change_table! 'commits_and_pushes' do
+        change_column! 'errors_json', null: true do
+          up!   :text,   limit: 0xffff_ffff
+          down! :string, limit: 256
+        end
+      end
+
+      change_table! 'jira_issues' do
+        change_column! 'key', null: false do
+          up!   :string, limit: 255
+          down! :text,   limit: 0xffff
+        end
+        change_column! 'issue_type', null: false do
+          up!   :string, limit: 255
+          down! :text,   limit: 0xffff
+        end
+        change_column! 'summary', :text, null: false do
+          up!   limit: 0xffff_ffff
+          down! limit: 0xffff
+        end
+        change_column! 'status', null: false do
+          up!   :string, limit: 255
+          down! :text,   limit: 0xffff
+        end
+        change_column! 'post_deploy_check_status', null: true do
+          up!   :string, limit: 255
+          down! :text,   limit: 0xffff
+        end
+        change_column! 'deploy_type', null: true do
+          up!   :string, limit: 255
+          down! :text,   limit: 0xffff
+        end
+        change_column! 'long_running_migration', null: true do
+          up!   :string, limit: 255
+          down! :text,   limit: 0xffff
+        end
+      end
+
+      change_table! 'jira_issues_and_pushes' do
+        change_column! 'errors_json', null: true do
+          up!   :text,   limit: 0xffff_ffff
+          down! :string, limit: 256
+        end
+      end
+
+      change_table! 'repositories' do
+        change_column! 'name', null: false do
+          up!   :string, limit: 255
+          down! :text,   limit: 0xffff
+        end
+      end
+
+      change_table! 'users' do
+        change_column! 'name', null: false do
+          up!   :string, limit: 255
+          down! :text,   limit: 0xffff
+        end
+        change_column! 'email', null: false do
+          up!   :string, limit: 255
+          down! :text,   limit: 0xffff
+        end
+      end
+    end
+  end
+
+  private
+
+  def migrate!(&block)
+    dsl = MigrationDsl.new
+    dsl.instance_exec(&block)
+
+    reversible do |dir|
+      dsl.execute!(dir, self)
+    end
+  end
+
+  class MigrationDsl
+    def initialize
+      @tables = []
+    end
+
+    def change_table!(table, &block)
+      dsl = TableDsl.new(table)
+      dsl.instance_exec(&block)
+      @tables << dsl
+    end
+
+    def execute!(dir, binding)
+      @tables.each do |dsl|
+        dsl.execute!(dir, binding)
+      end
+    end
+  end
+
+  class TableDsl
+    def initialize(table)
+      @table = table
+      @columns = []
+    end
+
+    def change_column!(column_name, type = nil, **common_hash, &block)
+      dsl = ColumnDsl.new(column_name)
+      dsl.instance_exec(&block)
+      @columns << [dsl, type, common_hash]
+    end
+
+    def execute!(dir, binding)
+      binding.change_table @table do |table|
+        @columns.each do |column, type, common_hash|
+          column.execute!(dir, table, type, common_hash)
+        end
+      end
+    end
+  end
+
+  class ColumnDsl
+    def initialize(column_name)
+      @column_name = column_name
+      @up   = []
+      @down = []
+    end
+
+    def up!(type = nil, **hash)
+      @up << [:change, @column_name, type, hash]
+    end
+
+    def down!(type = nil, **hash)
+      @down << [:change, @column_name, type, hash]
+    end
+
+    def execute!(dir, table, common_type, common_hash)
+      execute_dir!(dir, table, common_type, common_hash, :up,   @up)
+      execute_dir!(dir, table, common_type, common_hash, :down, @down)
+    end
+
+    private
+
+    def execute_dir!(dir, table, common_type, common_hash, direction, commands)
+      dir.send(direction) do
+        commands.each do |init_args|
+          args = init_args.dup
+          if common_type
+            if common_type != args[1]
+              args[2] and raise ArgumentError, "common type #{common_type.inspect} clashes with explicit type #{args[2].inspect}"
+              args = args.dup
+              args[2] = common_type
+            end
+          else
+            args[2] or raise ArgumentError, "type must be given: #{args.inspect}"
+          end
+
+          args.last.merge!(common_hash)
+          table.send(*args)
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_22_230337) do
+ActiveRecord::Schema.define(version: 2020_10_25_185335) do
 
-  create_table "branches", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8",force: :cascade do |t|
+  create_table "branches", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "git_updated_at", null: false
-    t.text "name", null: false
+    t.string "name", limit: 1024, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "author_id", null: false
@@ -23,9 +23,9 @@ ActiveRecord::Schema.define(version: 2020_09_22_230337) do
     t.index ["repository_id"], name: "index_branches_on_repository_id"
   end
 
-  create_table "commits", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8",force: :cascade do |t|
-    t.text "sha", limit: 255, null: false
-    t.text "message", null: false
+  create_table "commits", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "sha", null: false
+    t.text "message", limit: 4294967295, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "author_id", null: false
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 2020_09_22_230337) do
   end
 
   create_table "commits_and_pushes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "errors_json", limit: 256
+    t.text "errors_json", limit: 4294967295
     t.boolean "ignore_errors", default: false, null: false
     t.integer "push_id", null: false
     t.integer "commit_id", null: false
@@ -47,8 +47,8 @@ ActiveRecord::Schema.define(version: 2020_09_22_230337) do
   create_table "delayed_jobs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
     t.integer "attempts", default: 0, null: false
-    t.text "handler", null: false
-    t.text "last_error"
+    t.text "handler", limit: 4294967295, null: false
+    t.text "last_error", limit: 4294967295
     t.datetime "run_at"
     t.datetime "locked_at"
     t.datetime "failed_at"
@@ -59,26 +59,26 @@ ActiveRecord::Schema.define(version: 2020_09_22_230337) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table "jira_issues", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8",force: :cascade do |t|
-    t.text "key",  null: false
-    t.text "issue_type",  null: false
-    t.text "summary",  null: false
-    t.text "status",  null: false
+  create_table "jira_issues", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "issue_type", null: false
+    t.text "summary", limit: 4294967295, null: false
+    t.string "status", null: false
     t.date "targeted_deploy_date"
-    t.text "post_deploy_check_status"
-    t.text "deploy_type"
+    t.string "post_deploy_check_status"
+    t.string "deploy_type"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "assignee_id"
     t.integer "parent_issue_id"
     t.text "secrets_modified"
-    t.text "long_running_migration"
+    t.string "long_running_migration"
     t.index ["assignee_id"], name: "index_jira_issues_on_assignee_id"
     t.index ["parent_issue_id"], name: "index_jira_issues_on_parent_issue_id"
   end
 
   create_table "jira_issues_and_pushes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "errors_json", limit: 256
+    t.text "errors_json", limit: 4294967295
     t.boolean "ignore_errors", default: false, null: false
     t.integer "push_id", null: false
     t.integer "jira_issue_id", null: false
@@ -87,34 +87,34 @@ ActiveRecord::Schema.define(version: 2020_09_22_230337) do
     t.index ["push_id"], name: "index_jira_issues_and_pushes_on_push_id"
   end
 
-  create_table "pushes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8",force: :cascade do |t|
+  create_table "pushes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "status", limit: 32, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "head_commit_id", null: false
     t.integer "branch_id", null: false
     t.boolean "email_sent", default: false, null: false
+    t.bigint "service_id", null: false
     t.index ["branch_id"], name: "index_pushes_on_branch_id"
-    t.integer "service_id", limit: 8, null: false
     t.index ["head_commit_id"], name: "index_pushes_on_head_commit_id"
     t.index ["service_id"], name: "on_service_id"
   end
 
-  create_table "repositories", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8",force: :cascade do |t|
-    t.text "name", null: false
+  create_table "repositories", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "services", id: :bigint, force: :cascade do |t|
-    t.string "name", limit: 255, null: false
-    t.string "ref", limit: 255, default: "master", null: false
+  create_table "services", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "ref", default: "master", null: false
     t.index ["name"], name: "on_name", unique: true
   end
 
-  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8",force: :cascade do |t|
-    t.text "name",  null: false
-    t.text "email", null: false
+  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "email", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end


### PR DESCRIPTION
- Migrated default `:text limit: 0xffff` (64 MiB) fields to the max `:text limit: 0xffff_ffff` (4 GiB).
- Migrated some small `text` fields to `string` since that is more efficient (and later can be indexed).
- Migrated some `string` to `text` so that will essentially be unlimited.
- [Cleanup] Removed sqlite from the README and Gemfile since we've moved to MySQL.
- [Bonus] Created a small DSL to DRY up the `reversible` migrations. I want to move this over to `declare_schema` and have it emit all its migrations this way. (They are now DRY--with unchanging options given once--and also, the `up`/`down` options are now on adjacent lines so the differences stand out.)

[Rails Guide to Migrations](https://guides.rubyonrails.org/active_record_migrations.html)